### PR TITLE
Use 'Cookie' instead of 'Received Cookie' for coherence with other tests

### DIFF
--- a/tests/data/parser/name0019-expected
+++ b/tests/data/parser/name0019-expected
@@ -1,1 +1,1 @@
-Received Cookie: "a=bar
+Cookie: "a=bar


### PR DESCRIPTION
All tests but `name0019` use `Cookie:` for expected cookies.
Change `name0019-expected` for more coherence.